### PR TITLE
Remove debug log from api middleware

### DIFF
--- a/mounts/api/middleware/renamePlacenames.js
+++ b/mounts/api/middleware/renamePlacenames.js
@@ -64,7 +64,6 @@ function renameOneRecord(place) {
     });
   }
 
-  console.log("place", place);
   return place;
 }
 


### PR DESCRIPTION
Realized this was here when I just went to go look at geosearch logs; it's very noisy and not helpful and was just for debugging. 