### PR TITLE
77: update netlify url from netlify.com to netlify.app

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -3,8 +3,8 @@ server {
     server_name geosearch.planninglabs.nyc;
     location / {
         proxy_set_header   X-Real-IP $remote_addr;
-        proxy_set_header   Host      labs-geosearch-docs.netlify.com;
-        proxy_pass           https://labs-geosearch-docs.netlify.com;
+        proxy_set_header   Host      labs-geosearch-docs.netlify.app;
+        proxy_pass           https://labs-geosearch-docs.netlify.app;
     }
     location /v1 {
         if ($request_method != GET) {


### PR DESCRIPTION
Update netlify url to `netlify.com` to `netlify.app` 

Connected to issue [#77](https://github.com/NYCPlanning/labs-infrastructure/issues/77)