### PR TITLE
Update normalize.sh to work with labs-geosearch-pad-normalize's latest Dockerfile

### DIFF
--- a/cmd/normalize.sh
+++ b/cmd/normalize.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e;
 
-function normalize_nycpad() { compose_run 'nycpad_normalizer' './bin/normalize' $@; }
+function normalize_nycpad() { compose_run 'nycpad_normalizer' $@; }
 register 'normalize' 'nycpad' '(re)download nycpad data, normalize, and save; version can optionally be specified' normalize_nycpad
 


### PR DESCRIPTION
When running through the README, I got an error when running `pelias normalize nycpad`.  It started with an odd message implying that the PAD version it was trying to download was called `./bin/normalize`:

```
[1] "Using PAD version:  ./bin/normalize"
```

After installing some R packages, I saw the text:

```
trying URL 'https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/pad./bin/normalize.zip'
Error in download.file(url, method = method, ...) :
  cannot open URL 'https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/pad./bin/normalize.zip'
Calls: source ... withVisible -> eval -> eval -> download -> download.file
In addition: Warning message:
In download.file(url, method = method, ...) :
  cannot open URL 'https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/pad./bin/normalize.zip': HTTP status was '404 Not Found'
Execution halted
```

It seemed to be barfing because it was pasting that "version" into a URL and understandably 404'ing.  After some investigation, I found https://github.com/NYCPlanning/labs-geosearch-pad-normalize/commit/b30cff77bc0746edaf7c7e4abede1a3ad1a48551, a commit made 6 months ago to the labs-geosearch-pad-normalize container's `Dockerfile`, which set an `ENTRYPOINT` of `"./bin/normalize"`.  This meant that running the container would actually call that script and pass it all the parameters passed to `docker run`, which, as it's used in `cmd/normalize.sh`, would be `"./bin/normalize"`:

```bash
function normalize_nycpad() { compose_run 'nycpad_normalizer' './bin/normalize' $@; }
```

Removing the first argument from the way this repository runs the container fixes the problem.

However, I should note that another potential fix would be to make a PR to labs-geosearch-pad-normalize's `Dockerfile` which changes the `ENTRYPOINT` to `COMMAND` (it's possible that's what was intended in the aforementioned commit).