### PR TITLE
Fix location of data volume on nycpad_normalizer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       context: "http://github.com/nycplanning/labs-geosearch-pad-normalize.git"
     container_name: pelias_nycpad_normalizer
     volumes:
-      - "${DATA_DIR}:/data"
+      - "${DATA_DIR}:/usr/local/src/scripts/data"
 
   # The ES backend
   elasticsearch:


### PR DESCRIPTION
The `docker-compose.yml` mounts the data volume on `/data`, but the actual container writes its data (which is later retrieved by the `nycpad` container for importing) to `/usr/local/src/scripts/data`.  This changes the location of the mount to match where data is written, so that everything works as expected when `pelias import nycpad` is run.