### PR TITLE
Fix pointing issues

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,6 @@
 server {
     listen 80 default_server;
-    server_name _;
+    server_name geosearch.planninglabs.nyc;
     location / {
         proxy_set_header   X-Real-IP $remote_addr;
         proxy_set_header   Host      labs-geosearch-docs.netlify.app;


### PR DESCRIPTION
planninglabs.nyc points to geosearch docs for unknown reasons. This should resolve the issue