### PR TITLE
Add java option env var to elasticsearch container to patch log4shell

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       DATA_DIR: ./data
       DOCKER_USER: 1100
-      DO_PAT: ${{ secrets.DO_PAT }}
+      DO_PAT: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
       PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
     steps:
     - uses: actions/checkout@v2
@@ -20,7 +20,7 @@ jobs:
     - name: Install doctl
       uses: digitalocean/action-doctl@v2
       with:
-        token: ${{ secrets.DO_PAT }}
+        token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
     - name: Install ssh key
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Install doctl
-      uses: digitalocean/action-doctl@v2.1
+      uses: digitalocean/action-doctl@v2.1.0
       with:
         token: ${{ secrets.DO_PAT }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       DATA_DIR: ./data
       DOCKER_USER: 1100
-      DO_PAT: ${{ secrets.DO_PAT }}
+      DO_PAT: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN}}
       PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
     steps:
     - uses: actions/checkout@v2
@@ -20,7 +20,7 @@ jobs:
     - name: Install doctl
       uses: digitalocean/action-doctl@v2.1.0
       with:
-        token: ${{ secrets.DO_PAT }}
+        token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
     - name: Install ssh key
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,15 +12,15 @@ jobs:
     env:
       DATA_DIR: ./data
       DOCKER_USER: 1100
-      DO_PAT: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      DO_PAT: ${{ secrets.DO_PAT }}
       PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
     steps:
     - uses: actions/checkout@v2
     
     - name: Install doctl
-      uses: digitalocean/action-doctl@v2
+      uses: digitalocean/action-doctl@v2.1
       with:
-        token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+        token: ${{ secrets.DO_PAT }}
 
     - name: Install ssh key
       run: |

--- a/cmd/terraform.sh
+++ b/cmd/terraform.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# temp
 set -e;
 PASSWORD=${PASSWORD:-$( echo pelias | openssl passwd -1 -stdin )}
 PVT_KEY=${PVT_KEY:-~/.ssh/terraform}

--- a/cmd/terraform.sh
+++ b/cmd/terraform.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# temp
 set -e;
 PASSWORD=${PASSWORD:-$( echo pelias | openssl passwd -1 -stdin )}
 PVT_KEY=${PVT_KEY:-~/.ssh/terraform}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
   # NYC PAD normalizer
   nycpad_normalizer:
     build:
-      context: "http://github.com/nycplanning/labs-geosearch-pad-normalize.git"
+      context: "http://github.com/nycplanning/labs-geosearch-pad-normalize.git#main"
     container_name: pelias_nycpad_normalizer
     volumes:
       - "${DATA_DIR}:/usr/local/src/scripts/data"
@@ -72,6 +72,8 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     ports: [ "9200:9200", "9300:9300" ]
+    environment:
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true"
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"
     ulimits:


### PR DESCRIPTION
This PR is meant to protect us from [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) aka "Log4Shell". Specifically, the stack of containers kicked off by this repo has ElasticSearch which is vulnerable to this exploit. As [suggested by ElasticSearch](https://discuss.elastic.co/t/apache-log4j2-remote-code-execution-rce-vulnerability-cve-2021-44228-esa-2021-31/291476?linkId=143856147), we update the docker-compose to set an environment variable that should remediate this for us. 