### PR TITLE
Update GH Action to trigger on branch master instead of main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: 'Build and Deploy'
 on: 
   push:
     branches:
-      - 'main'
+      - 'master'
   workflow_dispatch:
 jobs:
   create-droplet:


### PR DESCRIPTION
This is just a one line fix from a mistake in PR#64. This repo still uses `master` instead of `main` for it's default branch.