### PR TITLE
Remove proxy passing v1 calls to old droplet

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -6,15 +6,6 @@ server {
         proxy_set_header   Host      labs-geosearch-docs.netlify.app;
         proxy_pass           https://labs-geosearch-docs.netlify.app;
     }
-    location /v1 {
-        if ($request_method != GET) {
-            return 403;
-        }
-        proxy_set_header   X-Real-IP $remote_addr;
-        proxy_set_header   Host      $http_host;
-        # point to legacy Geosearch droplet
-        proxy_pass         http://167.99.20.18;
-    }
     location /v2 {
         if ($request_method != GET) {
             return 403;


### PR DESCRIPTION
### Summary
This PR remove the NGINX record that was responsible for forwarding traffic to `/v1` endpoints to an IP hosting the old version of Geosearch so that we can decommission that version.