### PR TITLE
Add missing semicolon to nginx.conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -7,7 +7,7 @@ server {
         proxy_pass           https://labs-geosearch-docs.netlify.app;
     }
     location /v1 {
-        return 410 "v1 API has been permanently removed. For details on migrating to the v2 API, see https://github.com/NYCPlanning/labs-geosearch-docker/blob/master/MIGRATING.md"
+        return 410 "v1 API has been permanently removed. For details on migrating to the v2 API, see https://github.com/NYCPlanning/labs-geosearch-docker/blob/master/MIGRATING.md";
     }
     location /v2 {
         if ($request_method != GET) {


### PR DESCRIPTION
### Summary
Adding a missing semicolon that was breaking the nginx server spun up by `docker-compose`.