### PR TITLE
Change v1 410 response to be JSON with error message

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -7,7 +7,8 @@ server {
         proxy_pass           https://labs-geosearch-docs.netlify.app;
     }
     location /v1 {
-        return 410 "v1 API has been permanently removed. For details on migrating to the v2 API, see https://github.com/NYCPlanning/labs-geosearch-docker/blob/master/MIGRATING.md";
+        default_type application/json;
+        return 410 '{"message": "v1 API has been permanently removed. For details on migrating to the v2 API, see https://github.com/NYCPlanning/labs-geosearch-docker/blob/master/MIGRATING.md"}';
     }
     location /v2 {
         if ($request_method != GET) {


### PR DESCRIPTION
### Summary
This change updates the response to calls made to the deprecated v1 endpoints so that they return JSON with the error message in the body