### PR TITLE
Add local logging driver to all active containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,9 @@ services:
     command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
     logging:
       driver: "local"
-    
+      options:
+        max-size: "200m"
+
   api:
     image: pelias/api:v5.53.0
     container_name: pelias_api
@@ -26,6 +28,8 @@ services:
       - "./pelias.json:/code/pelias.json"
     logging:
       driver: "local"
+      options:
+        max-size: "200m"
 
   schema:
     image: pelias/schema:v6.4.0
@@ -42,6 +46,8 @@ services:
     ports: [ "4400:4400" ]
     logging:
       driver: "local"
+      options:
+        max-size: "200m"
 
   csv-importer:
     image: pelias/csv-importer:v2.13.0
@@ -71,6 +77,8 @@ services:
       - "${DATA_DIR}:/data"
     logging:
       driver: "local"
+      options:
+        max-size: "200m"
 
   elasticsearch:
     image: pelias/elasticsearch:7.16.1
@@ -92,3 +100,5 @@ services:
     cap_add: [ "IPC_LOCK" ]
     logging:
       driver: "local"
+      options:
+        max-size: "200m"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - "80:80"
       - "443:443"
     command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
+    logging:
+      driver: "local"
     
   api:
     image: pelias/api:v5.53.0
@@ -22,6 +24,8 @@ services:
     ports: [ "4000:4000" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
+    logging:
+      driver: "local"
 
   schema:
     image: pelias/schema:v6.4.0
@@ -36,6 +40,8 @@ services:
     user: "${DOCKER_USER}"
     restart: always
     ports: [ "4400:4400" ]
+    logging:
+      driver: "local"
 
   csv-importer:
     image: pelias/csv-importer:v2.13.0
@@ -63,6 +69,8 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "${DATA_DIR}:/data"
+    logging:
+      driver: "local"
 
   elasticsearch:
     image: pelias/elasticsearch:7.16.1
@@ -82,3 +90,5 @@ services:
         soft: 65536
         hard: 65536
     cap_add: [ "IPC_LOCK" ]
+    logging:
+      driver: "local"

--- a/pelias.json
+++ b/pelias.json
@@ -39,5 +39,10 @@
         "85977539"
       ]
     }
+  },
+  "logger": {
+    "level": "http",
+    "timestamp": true,
+    "colorize": true
   }
 }


### PR DESCRIPTION
Closes #74 

Based off findings in the discussion https://github.com/NYCPlanning/ae-private/discussions/9, I added local logging drivers to all active containers: `pelias_elasticsearch`, `pelias_api`, `pelias_libpostal`, `pelias_pip_service`, and `labs-geosearch-docker-nginx-1`.

In the malfunctioning droplet instance, `pelias_api`'s logs take up the most space at 138G, and `labs-geosearch-docker-nginx-1`'s logs next with 3.6G. 

I chose to add to all the services for consistency and to ensure that if something goes wrong, it won't be because of logging on disk space for any of the containers. 