### PR TITLE
Upgrade to NGINX 1.26

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ networks:
     driver: bridge
 services:
   nginx:
-    image: nginx:1.24-alpine
+    image: nginx:1.26.1-alpine3.19-slim
     restart: unless-stopped
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/nginx.conf


### PR DESCRIPTION
This PR updates the version of NGINX specified in `docker-compose.yml` to 1.26.